### PR TITLE
Fix decode function for IpModeControl

### DIFF
--- a/src/docsis_symtable.h
+++ b/src/docsis_symtable.h
@@ -1582,7 +1582,7 @@ symbol_type symtable[NUM_IDENTIFIERS] =  {
 
 /* eSTB Settings */
 { 1532,    "EstbSettings",                     217,     0,      (encode_nothing),        (decode_aggregate),      0,           0             }, /* TLV 217 eDOCSIS-I30 5.2.8.1 */
-{ 1533,    "IpModeControl",                    1,       1532,   (encode_uchar),          (encode_uchar),          0,           2             }, /* TLV 217.1 HOST2.1-I17 15.2.6 */
+{ 1533,    "IpModeControl",                    1,       1532,   (encode_uchar),          (decode_uchar),          0,           2             }, /* TLV 217.1 HOST2.1-I17 15.2.6 */
 { 1534,    "Snmpv1v2Settings",                 53,      1532,   (encode_nothing),        (decode_aggregate),      0,           0             }, /* TLV 217.53 HOST2.1-I17 15.2.1 */
 { 1535,    "Snmpv1v2CommunityName",            1,       1534,   (encode_string),         (decode_string),         1,           32            }, /* TLV 217.53.1 HOST2.1-I17 15.2.1.1 */
 


### PR DESCRIPTION
The encode function was listed twice.  The second one should be the decode function.  This fixes a compliation warning:

./docsis_symtable.h:1585:90: error: incompatible function pointer types initializing 'decode_func_t' (aka 'void (*)(unsigned char *, struct symbol_entry *, unsigned long)') with an expression of type 'int (unsigned char *, void *, struct symbol_entry *)' [-Wincompatible-function-pointer-types]

Closes #74
Signed-off-by: Richard Laager <rlaager@wiktel.com>